### PR TITLE
fix(iOS): 兼容 UIScene 生命周期，修复广告展示无效 VC/Window 问题

### DIFF
--- a/ios/Classes/banner/BannerAd.m
+++ b/ios/Classes/banner/BannerAd.m
@@ -51,6 +51,20 @@
 
 @implementation BannerAd
 
+- (UIViewController *)currentAdViewController{
+    UIViewController *controller = [UIViewController jsd_getCurrentViewController];
+    if (controller == nil) {
+        controller = [UIViewController jsd_getRootViewController];
+    }
+    return controller;
+}
+
+- (void)notifyVCInvalid{
+    [[TLogUtil sharedInstance] print:@"Banner展示失败：未获取到有效vc"];
+    NSDictionary *dictionary = @{@"code":@(-1),@"message":@"广告展示的时候未收到开发者传递的有效的vc参数"};
+    [self.channel invokeMethod:@"onFail" arguments:dictionary result:nil];
+}
+
 - (instancetype)initWithWithFrame:(CGRect)frame viewIdentifier:(int64_t)viewId arguments:(id)args binaryMessenger:(NSObject<FlutterBinaryMessenger> *)messenger{
     if ([super init]) {
         NSDictionary *dic = args;
@@ -91,11 +105,19 @@
 -(void)loadBannerAd{
     [_container removeFromSuperview];
     CGRect rect = {CGPointZero, CGSizeMake(_viewWidth, _viewHeight)};
-    if(self.banner == nil){
-        self.banner = [[GDTUnifiedBannerView alloc] initWithFrame:rect placementId:_codeId viewController:[UIViewController jsd_getCurrentViewController]];
-        self.banner.delegate = self;
-        self.banner.autoSwitchInterval = 30;
+    UIViewController *controller = [self currentAdViewController];
+    if (controller == nil) {
+        [self notifyVCInvalid];
+        return;
     }
+    if(self.banner != nil){
+        self.banner.delegate = nil;
+        [self.banner removeFromSuperview];
+        self.banner = nil;
+    }
+    self.banner = [[GDTUnifiedBannerView alloc] initWithFrame:rect placementId:_codeId viewController:controller];
+    self.banner.delegate = self;
+    self.banner.autoSwitchInterval = 30;
     self.container = self.banner;
     [self.banner loadAdAndShow];
 }

--- a/ios/Classes/insert/InsertAd.m
+++ b/ios/Classes/insert/InsertAd.m
@@ -34,6 +34,22 @@
     return myInstance;
 }
 
+- (UIViewController *)currentAdViewController{
+    UIViewController *controller = [UIViewController jsd_getCurrentViewController];
+    if (controller == nil) {
+        controller = [UIViewController jsd_getRootViewController];
+    }
+    return controller;
+}
+
+- (void)notifyVCInvalid{
+    NSDictionary *dictionary = @{@"adType":@"interactAd",
+                                 @"onAdMethod":@"onFail",
+                                 @"code":@(-1),
+                                 @"message":@"广告展示的时候未收到开发者传递的有效的vc参数"};
+    [[FlutterTencentAdEvent sharedInstance] sentEvent:dictionary];
+}
+
 //预加载激励广告
 -(void)initAd:(NSDictionary*)arguments{
     NSDictionary *dic = arguments;
@@ -48,6 +64,11 @@
 
 //展示广告
 - (void)showAd:(NSDictionary*)arguments{
+    UIViewController *controller = [self currentAdViewController];
+    if (controller == nil) {
+        [self notifyVCInvalid];
+        return;
+    }
     if(self.isBidding){
         BOOL isSuccess = [arguments[@"isSuccess"] boolValue];
         if(isSuccess){
@@ -55,9 +76,9 @@
                                          GDT_M_W_H_LOSS_PRICE:@([arguments[@"highestLossPrice"] intValue])};
             [self.interstitialAd sendWinNotificationWithInfo:dictionary];
             if(_isFullScreen){
-                [_interstitialAd presentFullScreenAdFromRootViewController:[UIViewController jsd_getCurrentViewController]];
+                [_interstitialAd presentFullScreenAdFromRootViewController:controller];
             }else{
-                [_interstitialAd presentAdFromRootViewController:[UIViewController jsd_getCurrentViewController]];
+                [_interstitialAd presentAdFromRootViewController:controller];
             }
         }else{
             NSDictionary *dictionary = @{GDT_M_L_WIN_PRICE:@([arguments[@"winPrice"] intValue]),
@@ -67,9 +88,9 @@
         }
     }else{
         if(_isFullScreen){
-            [_interstitialAd presentFullScreenAdFromRootViewController:[UIViewController jsd_getCurrentViewController]];
+            [_interstitialAd presentFullScreenAdFromRootViewController:controller];
         }else{
-            [_interstitialAd presentAdFromRootViewController:[UIViewController jsd_getCurrentViewController]];
+            [_interstitialAd presentAdFromRootViewController:controller];
         }
     }
 }

--- a/ios/Classes/native/NativeAd.m
+++ b/ios/Classes/native/NativeAd.m
@@ -52,6 +52,14 @@
 #pragma mark - NativeAd
 @implementation NativeAd
 
+- (UIViewController *)currentAdViewController{
+    UIViewController *controller = [UIViewController jsd_getCurrentViewController];
+    if (controller == nil) {
+        controller = [UIViewController jsd_getRootViewController];
+    }
+    return controller;
+}
+
 - (instancetype)initWithWithFrame:(CGRect)frame viewIdentifier:(int64_t)viewId arguments:(id)args binaryMessenger:(NSObject<FlutterBinaryMessenger> *)messenger{
     if ([super init]) {
         NSDictionary *dic = args;
@@ -105,10 +113,16 @@
  */
 - (void)nativeExpressAdSuccessToLoad:(GDTNativeExpressAd *)nativeExpressAd views:(NSArray<__kindof GDTNativeExpressAdView *> *)views{
     [[TLogUtil sharedInstance] print:@"拉取原生模板广告成功"];
+    UIViewController *controller = [self currentAdViewController];
+    if (controller == nil) {
+        NSDictionary *dictionary = @{@"code":@(-1),@"message":@"广告展示的时候未收到开发者传递的有效的vc参数"};
+        [_channel invokeMethod:@"onFail" arguments:dictionary result:nil];
+        return;
+    }
     if (views.count) {
         [views enumerateObjectsUsingBlock:^(id  _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
             self.nativeView = (GDTNativeExpressAdView *)obj;
-            self.nativeView.controller = [UIViewController jsd_getCurrentViewController];
+            self.nativeView.controller = controller;
             //是否开启竞价
             if(self.isBidding){
                 NSDictionary *dictionary = @{@"ecpmLevel":self.nativeView.eCPMLevel == nil ? @"" : self.nativeView.eCPMLevel,@"ecpm":@(self.nativeView.eCPM)};

--- a/ios/Classes/reward/RewardAd.m
+++ b/ios/Classes/reward/RewardAd.m
@@ -32,6 +32,22 @@
     return myInstance;
 }
 
+- (UIViewController *)currentAdViewController{
+    UIViewController *controller = [UIViewController jsd_getCurrentViewController];
+    if (controller == nil) {
+        controller = [UIViewController jsd_getRootViewController];
+    }
+    return controller;
+}
+
+- (void)notifyVCInvalid{
+    NSDictionary *dictionary = @{@"adType":@"rewardAd",
+                                 @"onAdMethod":@"onFail",
+                                 @"code":@(-1),
+                                 @"message":@"广告展示的时候未收到开发者传递的有效的vc参数"};
+    [[FlutterTencentAdEvent sharedInstance] sentEvent:dictionary];
+}
+
 //预加载激励广告
 -(void)initAd:(NSDictionary*)arguments{
     NSDictionary *dic = arguments;
@@ -71,7 +87,12 @@
             NSDictionary *dictionary = @{GDT_M_W_E_COST_PRICE:@([arguments[@"expectCostPrice"] intValue]),
                                          GDT_M_W_H_LOSS_PRICE:@([arguments[@"highestLossPrice"] intValue])};
             [self.reward sendWinNotificationWithInfo:dictionary];
-            [self.reward showAdFromRootViewController:[UIViewController jsd_getCurrentViewController]];
+            UIViewController *controller = [self currentAdViewController];
+            if (controller == nil) {
+                [self notifyVCInvalid];
+                return;
+            }
+            [self.reward showAdFromRootViewController:controller];
         }else{
             NSDictionary *dictionary = @{GDT_M_L_WIN_PRICE:@([arguments[@"winPrice"] intValue]),
                                          GDT_M_L_LOSS_REASON:@([arguments[@"lossReason"] intValue]),
@@ -79,7 +100,12 @@
             [self.reward sendWinNotificationWithInfo:dictionary];
         }
     }else{
-        [self.reward showAdFromRootViewController:[UIViewController jsd_getCurrentViewController]];
+        UIViewController *controller = [self currentAdViewController];
+        if (controller == nil) {
+            [self notifyVCInvalid];
+            return;
+        }
+        [self.reward showAdFromRootViewController:controller];
     }
     
 }

--- a/ios/Classes/splash/SplashAd.m
+++ b/ios/Classes/splash/SplashAd.m
@@ -8,6 +8,7 @@
 #import "SplashAd.h"
 #import "GDTMobSDK/GDTSplashAd.h"
 #import "TLogUtil.h"
+#import "TUIViewController+getCurrentVC.h"
 
 @implementation SplashAdFactory{
     NSObject<FlutterBinaryMessenger>*_messenger;
@@ -49,6 +50,17 @@
 
 @implementation SplashAd
 
+- (void)showSplashAdIfPossible{
+    UIWindow *window = [UIViewController jsd_getKeyWindow];
+    if (window == nil) {
+        [[TLogUtil sharedInstance] print:@"开屏广告展示失败：未获取到有效window"];
+        NSDictionary *dictionary = @{@"code":@(-1),@"message":@"广告展示的时候未收到有效window参数"};
+        [_channel invokeMethod:@"onFail" arguments:dictionary result:nil];
+        return;
+    }
+    [self.splash showFullScreenAdInWindow:window withLogoImage:nil skipView:nil];
+}
+
 - (instancetype)initWithWithFrame:(CGRect)frame viewIdentifier:(int64_t)viewId arguments:(id)args binaryMessenger:(NSObject<FlutterBinaryMessenger> *)messenger{
     if ([super init]) {
         NSDictionary *dic = args;
@@ -66,7 +78,7 @@
                                              GDT_M_W_H_LOSS_PRICE:@([call.arguments[@"highestLossPrice"] intValue])};
                 [self.splash sendWinNotificationWithInfo:dictionary];
                 //展示广告
-                [self.splash showFullScreenAdInWindow:[UIApplication sharedApplication].keyWindow withLogoImage:nil skipView:nil];
+                [self showSplashAdIfPossible];
                 //竞价失败
             } else if([@"biddingFail" isEqualToString:call.method]) {
                 NSDictionary *dictionary = @{GDT_M_L_WIN_PRICE:@([call.arguments[@"winPrice"] intValue]),
@@ -117,7 +129,7 @@
         NSDictionary *dictionary = @{@"ecpmLevel":self.splash.eCPMLevel == nil ? @"" : self.splash.eCPMLevel,@"ecpm":@(self.splash.eCPM)};
         [_channel invokeMethod:@"onECPM" arguments:dictionary result:nil];
     }else{
-        [self.splash showFullScreenAdInWindow:[UIApplication sharedApplication].keyWindow withLogoImage:nil skipView:nil];
+        [self showSplashAdIfPossible];
     }
 }
 

--- a/ios/Classes/utils/TUIViewController+getCurrentVC.h
+++ b/ios/Classes/utils/TUIViewController+getCurrentVC.h
@@ -15,6 +15,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (UIViewController *)jsd_getRootViewController;
 
++ (UIWindow *)jsd_getKeyWindow;
+
 + (UIViewController *)getCurrentVCWithCurrentView:(UIView *)currentView;
 
 +(UITabBarController *)currentTtabarController;

--- a/ios/Classes/utils/TUIViewController+getCurrentVC.m
+++ b/ios/Classes/utils/TUIViewController+getCurrentVC.m
@@ -11,38 +11,114 @@
 @implementation UIViewController (getCurrentVC)
 
 
++ (UIWindow *)jsd_getKeyWindow{
+    UIWindow *window = nil;
+
+    if (@available(iOS 13.0, *)) {
+        NSSet<UIScene *> *connectedScenes = UIApplication.sharedApplication.connectedScenes;
+        for (UIScene *scene in connectedScenes) {
+            if (![scene isKindOfClass:[UIWindowScene class]]) {
+                continue;
+            }
+            UIWindowScene *windowScene = (UIWindowScene *)scene;
+            if (windowScene.activationState != UISceneActivationStateForegroundActive) {
+                continue;
+            }
+            for (UIWindow *item in windowScene.windows) {
+                if (item.isKeyWindow) {
+                    return item;
+                }
+            }
+            for (UIWindow *item in windowScene.windows) {
+                if (!item.isHidden && item.windowLevel == UIWindowLevelNormal) {
+                    window = item;
+                    break;
+                }
+            }
+            if (window != nil) {
+                return window;
+            }
+        }
+    }
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    window = UIApplication.sharedApplication.keyWindow;
+#pragma clang diagnostic pop
+    if (window != nil) {
+        return window;
+    }
+
+    for (UIWindow *item in UIApplication.sharedApplication.windows) {
+        if (item.isKeyWindow) {
+            return item;
+        }
+    }
+    for (UIWindow *item in UIApplication.sharedApplication.windows) {
+        if (!item.isHidden && item.windowLevel == UIWindowLevelNormal) {
+            return item;
+        }
+    }
+
+    return nil;
+}
+
 + (UIViewController *)jsd_getRootViewController{
-    
-    UIWindow* window = [[[UIApplication sharedApplication] delegate] window];
-    //NSAssert(window, @"The window is empty");
-    return window.rootViewController;
+    UIWindow *window = [self jsd_getKeyWindow];
+    if (window.rootViewController != nil) {
+        return window.rootViewController;
+    }
+
+    for (UIWindow *item in UIApplication.sharedApplication.windows) {
+        if (item.rootViewController != nil) {
+            return item.rootViewController;
+        }
+    }
+    return nil;
 }
 
 + (UIViewController *)jsd_getCurrentViewController{
     
     UIViewController* currentViewController = [self jsd_getRootViewController];
+    if (currentViewController == nil) {
+        return nil;
+    }
     BOOL runLoopFind = YES;
     while (runLoopFind) {
-        if (currentViewController.presentedViewController) {
+        if (currentViewController.presentedViewController && !currentViewController.presentedViewController.isBeingDismissed) {
             
             currentViewController = currentViewController.presentedViewController;
         } else if ([currentViewController isKindOfClass:[UINavigationController class]]) {
             
             UINavigationController* navigationController = (UINavigationController* )currentViewController;
-            currentViewController = [navigationController.childViewControllers lastObject];
+            UIViewController *topVC = navigationController.topViewController ?: navigationController.visibleViewController;
+            if (topVC != nil) {
+                currentViewController = topVC;
+            } else if (navigationController.childViewControllers.count > 0) {
+                currentViewController = [navigationController.childViewControllers lastObject];
+            } else {
+                return navigationController;
+            }
             
         } else if ([currentViewController isKindOfClass:[UITabBarController class]]) {
             
             UITabBarController* tabBarController = (UITabBarController* )currentViewController;
-            currentViewController = tabBarController.selectedViewController;
+            if (tabBarController.selectedViewController != nil) {
+                currentViewController = tabBarController.selectedViewController;
+            } else {
+                return tabBarController;
+            }
         } else {
             
             NSUInteger childViewControllerCount = currentViewController.childViewControllers.count;
             if (childViewControllerCount > 0) {
                 
-                currentViewController = currentViewController.childViewControllers.lastObject;
-                
-                return currentViewController;
+                UIViewController *nextController = currentViewController.childViewControllers.lastObject;
+                if (nextController != nil && nextController != currentViewController) {
+                    currentViewController = nextController;
+                } else {
+                    return currentViewController;
+                }
             } else {
                 
                 return currentViewController;
@@ -67,7 +143,7 @@
 
 +(UITabBarController *)currentTtabarController
 {
-    UIWindow * window = [[UIApplication sharedApplication] keyWindow];
+    UIWindow * window = [self jsd_getKeyWindow];
     UIViewController *tabbarController = window.rootViewController;
     if ([tabbarController isKindOfClass:[UITabBarController class]]) {
         return (UITabBarController *)tabbarController;
@@ -77,7 +153,7 @@
 
 +(UINavigationController *)currentTabbarSelectedNavigationController
 {
-    UIWindow * window = [[UIApplication sharedApplication] keyWindow];
+    UIWindow * window = [self jsd_getKeyWindow];
     UIViewController *rootVC = window.rootViewController;
     if ([rootVC isKindOfClass:[UINavigationController class]]) {
         return (UINavigationController *)rootVC;


### PR DESCRIPTION
## 背景
在 iOS 13+ 开启 UIScene 的项目中，广告展示链路可能拿不到有效 `UIViewController` / `UIWindow`，导致展示失败（例如 GDT 5036：未收到有效 vc 参数）。

## 修改内容
1. `TUIViewController+getCurrentVC`
- 新增 `jsd_getKeyWindow`，优先从 `connectedScenes -> UIWindowScene.windows` 获取前台可用 window。
- 保留对旧生命周期的 fallback（`keyWindow` / `UIApplication.windows`）。
- `jsd_getRootViewController` / `jsd_getCurrentViewController` 改为基于新 window 解析。

2. `SplashAd`
- 展示时不再直接使用 `keyWindow`。
- 改为通过 `jsd_getKeyWindow` 获取 window，拿不到时回调 `onFail`。

3. `Banner/Reward/Insert/Native`
- 展示前统一获取当前可用 VC（`jsd_getCurrentViewController` + root fallback）。
- 若 VC 为空，主动回调失败，避免 SDK 侧静默失败或 5036。
- Banner 在重建时同步刷新 `viewController`，避免复用旧实例中的失效 VC。

## 影响范围
- iOS: Banner、插屏、激励、信息流、开屏
- Android: 无改动

## 验证建议
- iOS 13+（UIScene 开启）与老生命周期项目分别验证：
  - Banner 加载与展示
  - 激励/插屏展示
  - 开屏展示
  - 信息流渲染
- 重点确认不再出现 `无效 vc/window` 导致的展示失败。